### PR TITLE
Overhaul currentUser mechanic in SavnacRepository.java

### DIFF
--- a/app/src/main/java/com/silisurfers/savnac/database/SavnacRepository.java
+++ b/app/src/main/java/com/silisurfers/savnac/database/SavnacRepository.java
@@ -26,6 +26,8 @@ public class SavnacRepository {
     private static SavnacRepository instance;
     private final ExecutorService writeExecutor = Executors.newFixedThreadPool(2);
 
+    private LiveData<SavnacUser> currentUser;
+
     private SavnacRepository(Context context) {
         db = SavnacDatabase.getInstance(context);
     }
@@ -39,8 +41,22 @@ public class SavnacRepository {
 
     //USERS**********
     //who is currently signed in?
+
+    // Author: Brandon Evans (for this method only)
     public LiveData<SavnacUser> getCurrentUser() {
-        return db.savnacUserDao().getFirstUserSync();
+        if (this.currentUser == null) {
+            // This check is here for debugging purposes it should be removed when application is finished.
+            return db.savnacUserDao().getFirstUserSync();
+        } else {
+            // Get the current user, used in various parts of the application.
+            return this.currentUser;
+        }
+    }
+
+    // Author: Brandon Evans (for this method only)
+    public void setCurrentUser(LiveData<SavnacUser> user) {
+        // Set the current user to the specified user, used when logging in and signing up.
+        this.currentUser = user;
     }
 
     //all users (for debugging)


### PR DESCRIPTION
@vmc0823 So I came up with a better solution for getCurrentUser. Instead of always getting the first user (which is what I think it is currently doing), I made a LiveData<SavnacUser> variable inside SavnacRepository called currentUser and made getCurrentUser a getter method for that. I also added a setter method which I use when the user logs in or signs up. I am going to open a pull request and you can take a look at it. I tested it and doing this would also allow for everyone else's getCurrentUser checks to not need any changes. I know that this is stretching into your territory a bit so let me know what you think. Thanks